### PR TITLE
Set up tsconfig and scripts for building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 
 # Calendar Files
 *.ics
+
+# Built files
+dist/

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "name": "uoy-week-calendar",
   "version": "0.1.0",
   "description": "",
-  "main": "src/generate.ts",
+  "main": "dist/generate.js",
   "scripts": {
     "generate": "ts-node src/generate.ts",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "dev": "nodemon src/server.ts",
-    "dev:print": "nodemon src/print.ts"
+    "dev:print": "nodemon src/print.ts",
+    "build": "tsc",
+    "prepack": "tsc"
   },
   "repository": {
     "type": "git",

--- a/src/print.ts
+++ b/src/print.ts
@@ -17,7 +17,7 @@ for (let academicYear of academicYears) {
         for (let i = 0; i <= weeks; i++) {
             let currentDate = dayjs(startDate).add(i, 'week').toDate();
 
-            console.log(`${currentDate.toISOString()}: ${currentPeriod.getWeekName(currentDate)} - ${currentPeriod.getWeekDescription(currentDate, calendarType)}`)
+            console.log(`${currentDate.toISOString()}: ${currentPeriod.getWeekName(currentDate, calendarType)}`)
         }
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -44,12 +44,12 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -99,5 +99,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
This PR configures tsconfig.json to output built JS files and .d.ts declaration files in `dist`, and adds a `prepack` step so package managers build it on installing it (and eventually if this is published on NPM it'd get built for that too).

Also drive-by type error fix in print.ts.