### PR TITLE
fix(getWeeksBetween): correctly handle differing timezones

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -369,7 +369,12 @@ export const academicYears: AcademicYear[] = [
     }
 ];
 
-export function getWeeksBetween(startDate: Date, endDate: Date): number {
+export function getWeeksBetween(rawStartDate: Date, endDate: Date): number {
+    // startDate and endDate might not be in the same timezone (in particular around the BST transition)
+    let startDate = rawStartDate;
+    if (startDate.getTimezoneOffset() != endDate.getTimezoneOffset()) {
+        startDate = dayjs(startDate).add(startDate.getTimezoneOffset() - endDate.getTimezoneOffset(), 'minute').toDate();
+    }
     return Math.abs(dayjs(endDate).diff(dayjs(startDate), 'weeks'));
 }
 


### PR DESCRIPTION
`getWeeksBetween` could return incorrect results if the two dates are in different timezones, for example around the Daylight Savings Time transition. This PR makes it adjust them to be in the same timezone before calculating.